### PR TITLE
Add and install desktop file

### DIFF
--- a/icecream-sundae.desktop
+++ b/icecream-sundae.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=icecream-sundae
+GenericName=Icecream Monitor
+Comment=Commandline Monitor for Icecream
+Exec=icecream-sundae
+Type=Application
+Terminal=true
+Categories=ConsoleOnly;Development;Building;
+Keywords=icecc;icecream;monitor;network;

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,10 @@ icecream_sundae = executable('icecream-sundae',
     install : true
     )
 
+install_data('icecream-sundae.desktop',
+    install_dir: join_paths(get_option('datadir'), 'applications')
+    )
+
 # A pretty dumb test right now. Simply run the simulator with a known key for a
 # fixed number of iterations and see if anything breaks
 test('Random simulator test', icecream_sundae, is_parallel: false,


### PR DESCRIPTION
I'm just playing with packages for icecream-sundae ([copr for Fedora](https://copr.fedorainfracloud.org/coprs/stoupa/icecream-sundae/) and [OBS for openSUSE](https://software.opensuse.org/package/icecream-sundae)). I'm using icecream-sundae in GNOME, so the .desktop file is fine to easily start it through applications.

So this is a trivial stuff - just add the file and install it. I'm not sure if you'd like to put it into a directory. The validation of the file (i.e. `desktop-file-validate` for Fedora) is done in .spec file, not here in meson.