### PR TITLE
FIX: macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ python3.5 -m pip install --user meson
 export CXX=g++-6
 ```
 
+### macOS
+
+```shell
+brew install glib ncurses icecream
+export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig"
+```
+
 ## Compiling
 To build icecream-sundae, download the latest release, extract it, then run:
 ```

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ if not cxx.links(code, dependencies: deps, name: 'libicecc links dynamically')
     icecc = dependency('icecc', static: true)
     liblzo2 = cxx.find_library('lzo2')
     libcapng = dependency('libcap-ng', required: false)
+    libzstd = cxx.find_library('zstd', required: false)
     deps += [liblzo2, libcapng, libzstd]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,9 @@ project('icecream-sundae', 'cpp',
 
 icecc = dependency('icecc')
 glib = dependency('glib-2.0')
+
 ncurses = dependency('ncursesw')
+ncurses_cxxflag = '-DNCURSES_WIDECHAR'
 
 cxx = meson.get_compiler('cpp')
 
@@ -33,8 +35,8 @@ int main(int argc, char **argv)
 if not cxx.links(code, dependencies: deps, name: 'libicecc links dynamically')
     icecc = dependency('icecc', static: true)
     liblzo2 = cxx.find_library('lzo2')
-    libcapng = dependency('libcap-ng')
-    deps += [libcapng, liblzo2]
+    libcapng = dependency('libcap-ng', required: false)
+    deps += [liblzo2, libcapng, libzstd]
 endif
 
 incdir = include_directories('src')
@@ -64,7 +66,8 @@ icecream_sundae = executable('icecream-sundae',
     ['src/main.cpp', 'src/draw.cpp', 'src/scheduler.cpp', 'src/simulator.cpp'],
     include_directories: incdir,
     dependencies: deps,
-    install : true
+    install : true,
+    cpp_args: ncurses_cxxflag
     )
 
 install_data('icecream-sundae.desktop',


### PR DESCRIPTION
On macOS `ncursesw` is not available. Instead one needs to use `ncurses` (without `...w`) and define `-DNCURSES_WIDECHAR`. This patch for the meson build system should allow compiling and running on macOS.

Note that `ncurses` needs to be installed on the system first:

```bash
brew install ncurses
export PKG_CONFIG_PATH="/usr/local/opt/ncurses/lib/pkgconfig"
```

<img width="710" alt="Screenshot 2019-09-23 at 22 20 52" src="https://user-images.githubusercontent.com/1562139/65459772-db545d80-de50-11e9-81ac-8523862116ef.png">
