### PR TITLE
Avoid unnecessary ncurses clear() of the screen.

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -829,7 +829,7 @@ void NCursesInterface::doRender()
 
 void NCursesInterface::doRedraw()
 {
-    clear();
+    erase();
     doRender();
     refresh();
 }


### PR DESCRIPTION
Instead, just erase() the screen, so that it can be drawn over again and
then flushed at refresh() time.

This fixes the problem where redraws in a slow terminal (eg. mosh or
over a slow ssh link) sometimes render the cleared screen, causing a
distracting visible "flash".