### PR TITLE
Align the SPEED column

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <unordered_set>
@@ -345,9 +346,19 @@ struct IDColumn : SimpleColumn {
         : SimpleColumn(nc, "ID", 0, [](const HostCache& hc) { return hc.host->id; }) {}
 };
 
-struct SpeedColumn : SimpleColumn {
+class SpeedColumn : public SimpleColumn {
+private:
+    static auto extract(const HostCache& hc) { return hc.host->getSpeed(); }
+public:
+    // special formatting for speed so the decimal place lines up
     SpeedColumn(const NCursesInterface *nc)
-        : SimpleColumn(nc, "SPEED", 0, [](const HostCache& hc) { return hc.host->getSpeed(); }) {}
+        : SimpleColumn(nc, "SPEED", 8,
+                       [](std::ostream& ss, const HostCache& hc) {
+                           ss << std::fixed << std::setprecision(3) << std::setw(7) << extract(hc);
+                       },
+                       [](const HostCache& a, const HostCache& b) {
+                           return extract(a) < extract(b);
+                       }) {}
 };
 
 static const std::string local_job_track("abcdefghijklmnopqrstuvwxyz");

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -319,42 +319,42 @@ protected:
 
 struct InJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.host->total_in; }
-    InJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "IN", 5, &extract) {}
+    explicit InJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "IN", 5, &extract) {}
 };
 
 struct OutJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.host->total_out; }
-    OutJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "OUT", 5, &extract) {}
+    explicit OutJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "OUT", 5, &extract) {}
 };
 
 struct ActiveJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.active_jobs.size(); }
-    ActiveJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "ACTIVE", 0, &extract) {}
+    explicit ActiveJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "ACTIVE", 0, &extract) {}
 };
 
 struct PendingJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.pending_jobs.size(); }
-    PendingJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "PENDING", 0, &extract) {}
+    explicit PendingJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "PENDING", 0, &extract) {}
 };
 
 struct LocalJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.host->total_local; }
-    LocalJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "LOCAL", 5, &extract) {}
+    explicit LocalJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "LOCAL", 5, &extract) {}
 };
 
 struct CurrentJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.current_jobs.size(); }
-    CurrentJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "CUR", 0, &extract) {}
+    explicit CurrentJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "CUR", 0, &extract) {}
 };
 
 struct MaxJobsColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.host->getMaxJobs(); }
-    MaxJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "MAX", 0, &extract) {}
+    explicit MaxJobsColumn(const NCursesInterface *nc) : SimpleColumn(nc, "MAX", 0, &extract) {}
 };
 
 struct IDColumn : SimpleColumn {
     static decltype(auto) extract(const HostCache& hc) { return hc.host->id; }
-    IDColumn(const NCursesInterface *nc) : SimpleColumn(nc, "ID", 0, &extract) {}
+    explicit IDColumn(const NCursesInterface *nc) : SimpleColumn(nc, "ID", 0, &extract) {}
 };
 
 class SpeedColumn : public SimpleColumn {
@@ -370,7 +370,7 @@ private:
         return extract(a) < extract(b);
     }
 public:
-    SpeedColumn(const NCursesInterface *nc) : SimpleColumn(nc, "SPEED", 8, &_stream, &_compare) {}
+    explicit SpeedColumn(const NCursesInterface *nc) : SimpleColumn(nc, "SPEED", 8, &_stream, &_compare) {}
 };
 
 static const std::string local_job_track("abcdefghijklmnopqrstuvwxyz");

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -175,7 +175,8 @@ class Column {
     protected:
         explicit Column(const NCursesInterface *const interface): m_interface(interface) {}
 
-        virtual std::string getOutputString(const std::shared_ptr<const HostCache> &) const {
+        virtual std::string getOutputString(const std::shared_ptr<const HostCache> &) const
+        {
             return "";
         }
 
@@ -206,7 +207,8 @@ class NameColumn: public Column {
             }
         }
 
-        Compare get_compare() const override {
+        virtual Compare get_compare() const override
+        {
             return [](const HostCache &a, const HostCache &b) {
                 return a.host->getName() < b.host->getName();
             };
@@ -253,7 +255,8 @@ class JobsColumn: public Column {
             m_interface->print_job_graph(host->current_jobs, host->host->getMaxJobs(), width);
         }
 
-        Compare get_compare() const override {
+        virtual Compare get_compare() const override
+        {
             return [](const HostCache &a, const HostCache &b) {
                 return a.current_jobs.size() < b.current_jobs.size();
             };
@@ -796,14 +799,10 @@ void NCursesInterface::doRender()
     next_row();
 
     if (current_col < columns.size()) {
-        auto raw_compare = columns[current_col]->get_compare();
+        auto ascending = columns[current_col]->get_compare();
         auto compare = [&](const std::shared_ptr<const HostCache>& a,
                            const std::shared_ptr<const HostCache>& b) {
-            if (sort_reversed) {
-                return raw_compare(*a, *b);
-            } else {
-                return raw_compare(*b, *a);
-            }
+            return sort_reversed ? ascending(*b, *a) : ascending(*a, *b);
         };
         std::sort(host_cache.begin(), host_cache.end(), compare);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,7 +245,7 @@ Job::Map Host::getPendingJobs() const
 {
     Job::Map map;
 
-    for (auto j : Job::pendingJobs) {
+    for (auto&& j : Job::pendingJobs) {
         if (j.second->clientid == id)
             map[j.first] = j.second;
     }
@@ -257,7 +257,7 @@ Job::Map Host::getActiveJobs() const
 {
     Job::Map map;
 
-    for (auto j : Job::activeJobs) {
+    for (auto&& j : Job::activeJobs) {
         if (j.second->clientid == id)
             map[j.first] = j.second;
     }
@@ -269,7 +269,7 @@ Job::Map Host::getCurrentJobs() const
 {
     Job::Map map;
 
-    for (auto j : Job::activeJobs) {
+    for (auto&& j : Job::activeJobs) {
         if (j.second->hostid == id)
             map[j.first] = j.second;
     }


### PR DESCRIPTION
The primary change is to get the `SPEED` column to line its decimal points up.
Part of doing that was breaking down the SIMPLE_COLUMN macro into pure C++.

I think your for loops need reference indexes so I fixed those too.
Otherwise you copy each element into a loop variable unnecessarily.