### PR TITLE
fix compiler warnings range-loop-construct and format

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -153,7 +153,7 @@ class Column {
         {
             size_t min_width = std::max(getHeader().size(), getMinWidth());
 
-            for (auto const h : hosts) {
+            for (auto const &h : hosts) {
                 std::string s = getOutputString(h);
                 min_width = std::max(min_width, s.size());
             }
@@ -240,7 +240,7 @@ class JobsColumn: public Column {
             size_t min_width = getHeader().size();
             size_t desired_width = min_width;
 
-            for (auto const h : hosts)
+            for (auto const &h : hosts)
                 desired_width = std::max(desired_width, static_cast<size_t>(h->host->getMaxJobs()) + 2);
 
             return std::pair<size_t, size_t>(min_width, desired_width);
@@ -418,7 +418,7 @@ void NCursesInterface::print_job_graph(Job::Map const &jobs, int max_host_jobs, 
     std::vector<Bin> bins;
     int total_active_jobs = 0;
 
-    for (auto const j : jobs) {
+    for (auto const &j : jobs) {
         if (!j.second->active)
             continue;
 
@@ -545,13 +545,13 @@ void NCursesInterface::doRender()
 
     HostCache::List host_cache;
 
-    for (auto j : Job::allJobs) {
+    for (auto &j : Job::allJobs) {
         if (j.second->getHost()) {
             used_hosts.insert(j.second->getHost()->id);
         }
     }
 
-    for (auto const h : Host::hosts) {
+    for (auto const &h : Host::hosts) {
         if (!h.second->getNoRemote()) {
             avail_servers++;
             total_job_slots += h.second->getMaxJobs();
@@ -759,7 +759,7 @@ void NCursesInterface::doRender()
                 move(row, 2);
                 {
                     Attr bold(A_BOLD);
-                    printw("Job %d: ", i + 1);
+                    printw("Job %ld: ", i + 1);
                 }
 
                 std::shared_ptr<Job> job;

--- a/src/simulator.cpp
+++ b/src/simulator.cpp
@@ -98,7 +98,7 @@ template<typename T>
 std::shared_ptr<T> Simulator::chooseRandom(std::map<uint32_t, std::shared_ptr<T> > const &map)
 {
     std::vector<std::shared_ptr<T> > items;
-    for (auto const m : map)
+    for (auto const &m : map)
         items.push_back(m.second);
 
     if (!items.size())
@@ -227,7 +227,7 @@ Host::Map Simulator::getAvailableHosts(uint32_t except) const
 {
     Host::Map result;
 
-    for (auto h : Host::hosts) {
+    for (auto &h : Host::hosts) {
         if (h.first != except && h.second->getCurrentJobs().size() < h.second->getMaxJobs())
             result[h.first] = h.second;
     }


### PR DESCRIPTION
shut up the -Wrange-loop-construct and -Wformat compiler warnings. built with gcc 14.2.1 on gentoo.